### PR TITLE
Accept user creds with special chars in URL

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -246,7 +246,7 @@ var (
 	alphaDashPattern    = regexp.MustCompile("[^\\d\\w-_]")
 	alphaDashDotPattern = regexp.MustCompile("[^\\d\\w-_\\.]")
 	emailPattern        = regexp.MustCompile("[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@(?:[\\w](?:[\\w-]*[\\w])?\\.)+[a-zA-Z0-9](?:[\\w-]*[\\w])?")
-	urlPattern          = regexp.MustCompile(`(http|https):\/\/[\w\-_]+(\.[\w\-_]+)*([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
+	urlPattern          = regexp.MustCompile(`(http|https):\/\/(?:\\S+(?::\\S*)?@)?[\w\-_]+(\.[\w\-_]+)*([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
 )
 
 type (


### PR DESCRIPTION
Minor change. Currently user credential parts of a URL that contain special characters do not pass this regex. This just adds a small optional match to explicitly allow any characters in that initial user credentials part. In my case, quay.io webhooks include have a username of `$token`, which is where this fails currently.